### PR TITLE
Set formatter to a fixed locale to ensure the formate string is not rewritten

### DIFF
--- a/Sources/Validation/datetime.swift
+++ b/Sources/Validation/datetime.swift
@@ -18,6 +18,10 @@ func validateDateTime(_ context: Context, _ value: Any) -> AnySequence<Validatio
 
     let rfc3339DateTimeFormatter = DateFormatter()
 
+    /// Setting to a fixed locale because users can override the 12/24-hour format in the system settings, which causes DateFormatter to rewrite the format string
+    /// https://developer.apple.com/library/archive/qa/qa1480/_index.html
+    rfc3339DateTimeFormatter.locale = Locale(identifier: "en_US_POSIX")
+
     rfc3339DateTimeFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
     if rfc3339DateTimeFormatter.date(from: date) != nil {
       return AnySequence(EmptyCollection())


### PR DESCRIPTION
We use this package for the Corona-Warn-App on iOS and came across a bug. If the user deactivates the 24-hour format on their device (via Settings > General > Date & Time > 24-Hour Time) the date-time validation fails for e.g. "2021-07-21T17:00:00Z".

The reason can be found in https://developer.apple.com/library/archive/qa/qa1480/_index.html:
> On iOS, the user can override the default AM/PM versus 24-hour time setting (via Settings > General > Date & Time > 24-Hour Time), which causes NSDateFormatter to rewrite the format string you set, which can cause your time parsing to fail.

The solution is to set the `DateFormatter` to a fixed locale, Apple recommends `en_US_POSIX`.